### PR TITLE
Reorder Walkthrough videos for speller

### DIFF
--- a/problems/speller/speller.adoc
+++ b/problems/speller/speller.adoc
@@ -294,7 +294,7 @@ Alright, ready to go?
 
 == Walkthrough
 
-video::u9-1U1Rgo1o,hsruECgJJVQ,qTFnQ1nohM8,O3tErLhuEmY[youtube]
+video::u9-1U1Rgo1o,qTFnQ1nohM8,hsruECgJJVQ,O3tErLhuEmY[youtube]
 
 == Hints
 


### PR DESCRIPTION
Currently, the "speller / check" walkthrough plays before the "speller / load" video. Swapped the order of the two to be consistent with the order in which students are asked to complete the problem.