### PR TITLE
Add How to Submit heading for pset5

### DIFF
--- a/2016/fall/psets/5/pset5.adoc
+++ b/2016/fall/psets/5/pset5.adoc
@@ -57,6 +57,8 @@ Do keep in mind the course's policy on http://docs.cs50.net/2016/fall/syllabus/c
 
 * Implement link:../../../../problems/speller/speller.html[Speller]
 
+== How to Submit
+
 === Step 1 of 2
 
 * Update your IDE:

--- a/2016/fall/psets/5/yale.adoc
+++ b/2016/fall/psets/5/yale.adoc
@@ -57,6 +57,8 @@ Do keep in mind the course's policy on http://docs.cs50.net/2016/fall/syllabus/y
 
 * Implement link:../../../../problems/speller/speller.html[Speller]
 
+== How to Submit
+
 === Step 1 of 2
 
 * Update your IDE:


### PR DESCRIPTION
Current version of the pset5 spec doesn't include a "How to Submit" heading, and just puts submission instructions under "Problems." Modified the spec (along with Yale's) to be consistent with our previous "How to Submit" headings.