### PR TITLE
Fix code formatting in sentiments

### DIFF
--- a/problems/sentiments/sentiments.adoc
+++ b/problems/sentiments/sentiments.adoc
@@ -162,8 +162,8 @@ If you close that terminal window and/or open another, you'll need to repeat tho
 
 Next, try running
 
-[source]
-./smile
+[source,indent=0]
+ ./smile
 
 to see how it works. Keep in mind that all words will be classified (for now!) as neutral because of that hardcoded `0` in `analyze.py`.
 


### PR DESCRIPTION
There's a weird formatting issue in `sentiments` regarding how code was rendered:

<img width="381" alt="screen shot 2016-10-22 at 11 23 17 am" src="https://cloud.githubusercontent.com/assets/16066224/19620363/059c3888-984a-11e6-9439-3886fe881392.png">

Turns out any line beginning with a `.` is automatically rendered by asciidoc as a block title. Easiest way I could find to fix was just to add a space so that the line doesn't begin with `.`, and then have the `[source]` block remove the space via `indent=0`.