### PR TITLE
Linking edX account to CS50.me

### DIFF
--- a/2017/x/psets/0/pset0.adoc
+++ b/2017/x/psets/0/pset0.adoc
@@ -69,6 +69,8 @@ Oh, and if you'd like to exhibit your project in CS50x 2017's studio, head to ht
 
 Submit https://newforms.cs50.net/2017/x/psets/0[this form]!
 
-Your submission should be graded within 2 weeks, at which point your score will appear at https://cs50.me/[cs50.me]!
+Visit https://cs50.me/account/[cs50.me/account] and follow the link to connect your edX account to your new github account.  
+
+Your submission should be graded within 2 weeks, at which point your score will appear in your https://cs50.me/gradebook/course/cs50/2017/x[CS50.me Gradebook]!
 
 This was Problem Set 0.


### PR DESCRIPTION
Adding info to the submit instructions for pset0 making it clearer that students must link their edX account to their github account, and that grades appear in the Gradebook.