### PR TITLE
installing jekyll-asciidoc from rubygems [skip ci]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source "https://rubygems.org"
-
-# pull latest from GitHub else TOC disappears because of missing features from the version currently on RubyGems
-gem "jekyll-asciidoc", :git => "https://github.com/asciidoctor/jekyll-asciidoc.git"
-
+gem "jekyll-asciidoc"
 gem "jekyll-redirect-from"
 gem "pygments.rb"


### PR DESCRIPTION
since latest version is already on rubygems.org now