### PR TITLE
Update submission instructions

### DIFF
--- a/2017/x/project.adoc
+++ b/2017/x/project.adoc
@@ -14,7 +14,18 @@ If at a loss for ideas, turn to https://manual.cs50.net/seminars/[CS50's seminar
 
 == How to Submit
 
-Unlike problem sets, you don't actually have to submit the code that you write for your final project. (Or a pre-proposal, proposal, or status report, as are required on campus.) Rather, you only need to submit a short video (that's no more than 2 minutes in length) in which you present your project to the world, as with slides, screenshots, voiceover, and/or live action. Your video should somehow include your project's title, your name, your city and country, and any other details that you'd like to convey to viewers. See http://www.cs171.org/2015/screencast/ for tips from another class at Harvard on how to make a "screencast," though you're welcome to use an actual camera. Upload your video to YouTube (or, if blocked in your country, a similar site) and take note of its URL; it's fine to flag it as "unlisted," but don't flag it as "private."
+=== Step 1 of 2
+
+[source]
+----
+update50
+cd ~/workspace/project/
+submit50 cs50/2017/x/project
+----
+
+=== Step 2 of 2
+
+Submit a short video (that's no more than 2 minutes in length) in which you present your project to the world, as with slides, screenshots, voiceover, and/or live action. Your video should somehow include your project's title, your name, your city and country, and any other details that you'd like to convey to viewers. See http://www.cs171.org/2015/screencast/ for tips from another class at Harvard on how to make a "screencast," though you're welcome to use an actual camera. Upload your video to YouTube (or, if blocked in your country, a similar site) and take note of its URL; it's fine to flag it as "unlisted," but don't flag it as "private."
 
 When ready to submit your video, submit https://forms.cs50.net/2017/x/project[this form]!
 

--- a/2017/x/psets/0/pset0.adoc
+++ b/2017/x/psets/0/pset0.adoc
@@ -68,8 +68,16 @@ Oh, and if you'd like to exhibit your project in CS50x 2017's studio, head to ht
 == How to Submit
 
 1. Submit https://forms.cs50.net/2017/x/psets/0[this form]!
-1. Visit https://cs50.me/account/[cs50.me/account], and follow the link to connect your edX account to your GitHub account.  
+2. Visit https://cs50.me/account/[cs50.me/account], and follow the link to connect your edX account to your GitHub account.
+3. In your Scratch project, go to the "File" menu, and click "Download to your computer". Save the file as `project.sb2`.
+4. Go to https://github.com/submit50/USERNAME, where USERNAME is your GitHub username.
+5. On the left side of the screen, click on "Branch: master".
+6. In the field that says "Find or create a branch...", type `cs50/2017/x/scratch` and click "Create branch".
+7. Click the button that says "Upload files".
+8. Drag your `project.sb2` Scratch file into the box that says "Drag files here".
+9. Click the green "Commit changes" button.
+10. You're done!
 
-Your submission should be graded within 2 weeks, at which point your score will appear in https://cs50.me/gradebook/course/cs50/2017/x[CS50.me]!
+Your submission should be graded within 2 weeks, at which point your score will appear in https://cs50.me/gradebook!
 
 This was Problem Set 0.

--- a/2017/x/psets/0/pset0.adoc
+++ b/2017/x/psets/0/pset0.adoc
@@ -68,7 +68,7 @@ Oh, and if you'd like to exhibit your project in CS50x 2017's studio, head to ht
 == How to Submit
 
 1. Submit https://forms.cs50.net/2017/x/psets/0[this form]!
-2. Visit https://cs50.me/account/[cs50.me/account], and follow the link to connect your edX account to your GitHub account.
+2. Visit https://cs50.me/account[cs50.me/account], and follow the link to connect your edX account to your GitHub account.
 3. In your Scratch project, go to the "File" menu, and click "Download to your computer". Save the file as `project.sb2`.
 4. Go to https://github.com/submit50/USERNAME, where USERNAME is your GitHub username.
 5. On the left side of the screen, click on "Branch: master".

--- a/2017/x/psets/1/credit.adoc
+++ b/2017/x/psets/1/credit.adoc
@@ -79,7 +79,7 @@ If you'd like to check the correctness of your program with `check50`, you may e
 
 [source,bash]
 ----
-check50 2016.credit credit.c
+check50 cs50/2017/x/credit
 ----
 
 And if you'd like to play with the staff's own implementation of `credit` within CS50 IDE, you may execute the below.

--- a/2017/x/psets/1/mario-more.adoc
+++ b/2017/x/psets/1/mario-more.adoc
@@ -26,7 +26,7 @@ If you'd like to check the correctness of your program with `check50`, you may e
 
 [source,bash]
 ----
-check50 2016.mario.more mario.c
+check50 cs50/2017/x/mario/more
 ----
 
 If you'd like to play with the staff's own implementation of `mario` within CS50 IDE, you may execute the below.

--- a/2017/x/psets/1/pset1.adoc
+++ b/2017/x/psets/1/pset1.adoc
@@ -150,7 +150,7 @@ If any file is not in `~/workspace/pset1/`, move it into that directory, as via 
 [source]
 ----
 cd ~/workspace/pset1/
-submit50 2017/x/hello
+submit50 cs50/2017/x/hello
 ----
 +
 inputting your GitHub username and GitHub password as prompted.
@@ -159,7 +159,7 @@ inputting your GitHub username and GitHub password as prompted.
 [source]
 ----
 cd ~/workspace/pset1/
-submit50 2017/x/water
+submit50 cs50/2017/x/water
 ----
 +
 inputting your GitHub username and GitHub password as prompted.
@@ -168,7 +168,7 @@ inputting your GitHub username and GitHub password as prompted.
 [source]
 ----
 cd ~/workspace/pset1/
-submit50 2017/x/mario/less
+submit50 cs50/2017/x/mario/less
 ----
 +
 inputting your GitHub username and GitHub password as prompted.
@@ -177,7 +177,7 @@ inputting your GitHub username and GitHub password as prompted.
 [source]
 ----
 cd ~/workspace/pset1/
-submit50 2017/x/mario/more
+submit50 cs50/2017/x/mario/more
 ----
 +
 inputting your GitHub username and GitHub password as prompted.
@@ -186,7 +186,7 @@ inputting your GitHub username and GitHub password as prompted.
 [source]
 ----
 cd ~/workspace/pset1/
-submit50 2017/x/greedy
+submit50 cs50/2017/x/greedy
 ----
 +
 inputting your GitHub username and GitHub password as prompted.
@@ -195,7 +195,7 @@ inputting your GitHub username and GitHub password as prompted.
 [source]
 ----
 cd ~/workspace/pset1/
-submit50 2017/x/credit
+submit50 cs50/2017/x/credit
 ----
 +
 inputting your GitHub username and GitHub password as prompted.

--- a/2017/x/psets/2/pset2.adoc
+++ b/2017/x/psets/2/pset2.adoc
@@ -154,7 +154,7 @@ ls
 [source]
 ----
 cd ~/workspace/pset2/initials/
-submit50 2017/x/initials/less
+submit50 cs50/2017/x/initials/less
 ----
 +
 inputting your GitHub username and GitHub password as prompted.
@@ -163,7 +163,7 @@ inputting your GitHub username and GitHub password as prompted.
 [source]
 ----
 cd ~/workspace/pset2/initials/
-submit50 2017/x/initials/more
+submit50 cs50/2017/x/initials/more
 ----
 +
 inputting your GitHub username and GitHub password as prompted.
@@ -172,21 +172,21 @@ inputting your GitHub username and GitHub password as prompted.
 [source]
 ----
 cd ~/workspace/pset2/caesar/
-submit50 2017/x/caesar
+submit50 cs50/2017/x/caesar
 ----
 * To submit `vigenere` (if you implemented it), execute:
 +
 [source]
 ----
 cd ~/workspace/pset2/vigenere/
-submit50 2017/x/vigenere
+submit50 cs50/2017/x/vigenere
 ----
 * To submit `crack` (if you implemented it), execute:
 +
 [source]
 ----
 cd ~/workspace/pset2/crack/
-submit50 2017/x/crack
+submit50 cs50/2017/x/crack
 ----
 
 If you run into any trouble, email sysadmins@cs50.harvard.edu!

--- a/2017/x/psets/3/pset3.adoc
+++ b/2017/x/psets/3/pset3.adoc
@@ -91,21 +91,21 @@ update50
 [source]
 ----
 cd ~/workspace/pset3/find/
-submit50 2017/x/find/less
+submit50 cs50/2017/x/find/less
 ----
 * Submit the more-comfortable version of `find` (if you implemented it):
 +
 [source]
 ----
 cd ~/workspace/pset3/find/
-submit50 2017/x/find/more
+submit50 cs50/2017/x/find/more
 ----
 * Submit `fifteen`:
 +
 [source]
 ----
 cd ~/workspace/pset3/fifteen/
-submit50 2017/x/fifteen
+submit50 cs50/2017/x/fifteen
 ----
 
 === Step 2 of 2

--- a/2017/x/psets/4/pset4.adoc
+++ b/2017/x/psets/4/pset4.adoc
@@ -87,28 +87,28 @@ update50
 [source]
 ----
 cd ~/workspace/pset4/whodunit/
-submit50 2017/x/whodunit
+submit50 cs50/2017/x/whodunit
 ----
 * Submit the less-comfortable version of `resize` (if you implemented it):
 +
 [source]
 ----
 cd ~/workspace/pset4/resize/
-submit50 2017/x/resize/less
+submit50 cs50/2017/x/resize/less
 ----
 * Submit the more-comfortable version of `resize` (if you implemented it):
 +
 [source]
 ----
 cd ~/workspace/pset4/resize/
-submit50 2017/x/resize/more
+submit50 cs50/2017/x/resize/more
 ----
 * Submit `recover`:
 +
 [source]
 ----
 cd ~/workspace/pset4/recover/
-submit50 2017/x/recover
+submit50 cs50/2017/x/recover
 ----
 
 === Step 2 of 2

--- a/2017/x/psets/5/pset5.adoc
+++ b/2017/x/psets/5/pset5.adoc
@@ -75,7 +75,7 @@ update50
 [source]
 ----
 cd ~/workspace/pset5/speller/
-submit50 2017/x/speller
+submit50 cs50/2017/x/speller
 ----
 
 === Step 2 of 2

--- a/2017/x/psets/6/pset6.adoc
+++ b/2017/x/psets/6/pset6.adoc
@@ -124,7 +124,7 @@ Be sure you've signed up for a https://github.com/join[GitHub account], per Prob
 ----
 update50
 cd ~/workspace/pset6/
-submit50 2017/x/pset6
+submit50 cs50/2017/x/pset6
 ----
 
 === Step 2 of 2

--- a/2017/x/psets/7/pset7.adoc
+++ b/2017/x/psets/7/pset7.adoc
@@ -49,7 +49,7 @@ Be sure you've signed up for a https://github.com/join[GitHub account], per Prob
 ----
 update50
 cd ~/workspace/pset7/finance/
-submit50 2017/x/pset7
+submit50 cs50/2017/x/pset7
 ----
 
 === Step 2 of 2

--- a/2017/x/psets/8/pset8.adoc
+++ b/2017/x/psets/8/pset8.adoc
@@ -49,7 +49,7 @@ Be sure you've signed up for a https://github.com/join[GitHub account], per Prob
 ----
 update50
 cd ~/workspace/pset8/mashup/
-submit50 2017/x/pset8
+submit50 cs50/2017/x/pset8
 ----
 
 === Step 2 of 2

--- a/problems/caesar/caesar.adoc
+++ b/problems/caesar/caesar.adoc
@@ -131,7 +131,7 @@ Usage: ./caesar k
 
 [source]
 ----
-check50 2016.caesar caesar.c
+check50 cs50/2017/x/caesar
 ----
 
 == Staff's Solution

--- a/problems/credit/credit.adoc
+++ b/problems/credit/credit.adoc
@@ -96,7 +96,7 @@ INVALID
 
 [source,text]
 ----
-check50 2016.credit credit.c
+check50 cs50/2017/x/credit
 ----
 
 == Staff Solution

--- a/problems/fifteen/fifteen.adoc
+++ b/problems/fifteen/fifteen.adoc
@@ -127,7 +127,7 @@ Note that `check50` assumes that your board's blank space is implemented in `boa
 
 [source]
 ----
-check50 2016.fifteen fifteen.c
+check50 cs50/2017/x/fifteen
 ----
 
 == Staff's Solution

--- a/problems/find/less/find.adoc
+++ b/problems/find/less/find.adoc
@@ -329,7 +329,7 @@ you should see `1`, since `128` is, again, not among the 1,000 numbers outputted
 
 [source]
 ----
-check50 2016.find.less helpers.c
+check50 cs50/2017/x/find/less
 ----
 
 == Staff's Solution

--- a/problems/find/more/find.adoc
+++ b/problems/find/more/find.adoc
@@ -330,7 +330,7 @@ you should see `1`, since `128` is, again, not among the 1,000 numbers outputted
 
 [source]
 ----
-check50 2016.find.more helpers.c
+check50 cs50/2017/x/find/more
 ----
 
 == Staff's Solution

--- a/problems/greedy/greedy.adoc
+++ b/problems/greedy/greedy.adoc
@@ -71,7 +71,7 @@ Retry: [underline]#0.41#
 
 [source,text]
 ----
-check50 2016.greedy greedy.c
+check50 cs50/2017/x/greedy
 ----
 
 == Staff Solution

--- a/problems/hello/hello.adoc
+++ b/problems/hello/hello.adoc
@@ -124,7 +124,7 @@ Hello, world!
 
 [source,text]
 ----
-check50 2016.hello hello.c
+check50 cs50/2017/x/hello
 ----
 
 Assuming your program is correct, you should then see output like

--- a/problems/initials/less/initials.adoc
+++ b/problems/initials/less/initials.adoc
@@ -51,7 +51,7 @@ RTB
 
 [source]
 ----
-check50 2016.initials.less initials.c
+check50 cs50/2017/x/initials/less
 ----
 
 == Staff's Solution

--- a/problems/initials/more/initials.adoc
+++ b/problems/initials/more/initials.adoc
@@ -52,7 +52,7 @@ RTB
 
 [source]
 ----
-check50 2016.initials.more initials.c
+check50 cs50/2017/x/initials/more
 ----
 
 == Staff's Solution

--- a/problems/mario/less/mario.adoc
+++ b/problems/mario/less/mario.adoc
@@ -93,7 +93,7 @@ pass:[#####]
 
 [source,text]
 ----
-check50 2016.mario.less mario.c
+check50 cs50/2017/x/mario/less
 ----
 
 == Staff Solution

--- a/problems/mario/more/mario.adoc
+++ b/problems/mario/more/mario.adoc
@@ -86,7 +86,7 @@ pass:[####  ####]
 
 [source,text]
 ----
-check50 2016.mario.more mario.c
+check50 cs50/2017/x/mario/more
 ----
 
 == Staff Solution

--- a/problems/recover/recover.adoc
+++ b/problems/recover/recover.adoc
@@ -87,7 +87,7 @@ $ [underline]#echo $?#
 
 [source]
 ----
-check50 2016.recover recover.c
+check50 cs50/2017/x/recover
 ----
 
 == Staff's Solution

--- a/problems/resize/less/resize.adoc
+++ b/problems/resize/less/resize.adoc
@@ -104,7 +104,7 @@ Better yet, if you'd like to compare your outfile's headers against those from t
 
 [source]
 ----
-check50 2016.resize.less bmp.h resize.c
+check50 cs50/2017/x/resize/less
 ----
 
 == Staff's Solution

--- a/problems/resize/more/resize.adoc
+++ b/problems/resize/more/resize.adoc
@@ -116,7 +116,7 @@ Better yet, if you'd like to compare your outfile's headers against those from t
 
 [source]
 ----
-check50 2016.resize.more bmp.h resize.c
+check50 cs50/2017/x/resize/more
 ----
 
 == Staff's Solution

--- a/problems/speller/speller.adoc
+++ b/problems/speller/speller.adoc
@@ -394,7 +394,7 @@ To test your code less manually (though still not exhaustively), you may also ex
 
 [source]
 ----
-check50 2016.speller dictionary.c dictionary.h Makefile
+check50 cs50/2017/x/speller
 ----
 
 Note that `check50` does not check for memory leaks, so be sure to run `valgrind` as well.

--- a/problems/vigenere/vigenere.adoc
+++ b/problems/vigenere/vigenere.adoc
@@ -96,7 +96,7 @@ at your prompt, where `k` is some keyword. Presumably you'll want to paste your 
 
 [source]
 ----
-check50 2016.vigenere vigenere.c
+check50 cs50/2017/x/vigenere
 ----
 
 == Staff's Solution

--- a/problems/water/water.adoc
+++ b/problems/water/water.adoc
@@ -48,7 +48,7 @@ Bottles: 120
 
 [source,text]
 ----
-check50 2016.water water.c
+check50 cs50/2017/x/water
 ----
 
 == Staff Solution


### PR DESCRIPTION
This PR:

- Updates the instructions for `scratch` to include submission via GitHub.
- Updates the instructions for the final project to include submission via `submit50`.
- Updates the instructions of all problem sets to include `cs50/` at the beginning of slug names.