### PR TITLE
Remove exclamation point from link

### DIFF
--- a/2017/x/psets/0/pset0.adoc
+++ b/2017/x/psets/0/pset0.adoc
@@ -78,6 +78,6 @@ Oh, and if you'd like to exhibit your project in CS50x 2017's studio, head to ht
 9. Click the green "Commit changes" button.
 10. You're done!
 
-Your submission should be graded within 2 weeks, at which point your score will appear in https://cs50.me/gradebook!
+Your submission should be graded within 2 weeks, at which point your score will appear in https://cs50.me/gradebook[https://cs50.me/gradebook]!
 
 This was Problem Set 0.


### PR DESCRIPTION
It's causing some 404s right now because the `!` is being included in the URL