### PR TITLE
change url to lecture

### DIFF
--- a/_pages/2018/spring/psets/1/pset1.adoc
+++ b/_pages/2018/spring/psets/1/pset1.adoc
@@ -9,7 +9,7 @@ toc: false
 == tl;dr
 
 [start=0]
-. Attend or watch https://video.cs50.net/2018/spring/lectures/1[Week 1's first lecture].
+. Attend or watch https://video.cs50.net/2017/fall/lectures/1[Week 1's first lecture].
 . Get your CS50 IDE set up with `hello.c`.
 . Recreate one of Mario's pyramids, in `mario.c`.
 . Accept some cash in `cash.c` or credit in `credit.c`.


### PR DESCRIPTION
The link fails. pretty sure it should be going to 2017/fall instead.