### PR TITLE
pset0 add back the FAQ about branch:master

### DIFF
--- a/_pages/2018/x/psets/0/pset0.adoc
+++ b/_pages/2018/x/psets/0/pset0.adoc
@@ -100,3 +100,9 @@ If you don't see results on cs50.me[https://cs50.me/], make sure that your branc
 Submit https://forms.cs50.net/2018/x/psets/0.
 
 This was Problem Set 0.
+
+== FAQs
+
+=== Can't find the "Branch: master" button.
+
+If you don't see a "Branch: master" button upon going to your submit50 page on GitHub, click the "README" button next to "We recommend every repository include a..." and then click the green "Commit new file" button. After that, the "Branch: master" button should appear!


### PR DESCRIPTION
This is still an issue so I've put back the FAQ that we had in the 2017/x version of the pset.