### PR TITLE
update lecture 11 notes to correct sample syntax

### DIFF
--- a/_pages/2017/fall/notes/11/lecture11.adoc
+++ b/_pages/2017/fall/notes/11/lecture11.adoc
@@ -97,7 +97,7 @@ for (let value of array)
     ...
 }
 
-for (let key in array)
+for (let key in object)
 {
     ...
 }


### PR DESCRIPTION
Per the slide, `let key in object` (said `array` in error)