### PR TITLE
update resize - move sections

### DIFF
--- a/_pages/2018/fall/psets/3/resize/less/resize.adoc
+++ b/_pages/2018/fall/psets/3/resize/less/resize.adoc
@@ -17,6 +17,23 @@ $ [underline]#./resize 4 small.bmp large.bmp#
 
 video::HmBtQJDiVm8[youtube]
 
+== Getting Started
+
+Here's how to download this problem's "distribution code" (i.e., starter code) into your own CS50 IDE. Log into [CS50 IDE](https://cs50.io/) and then, in a terminal window, execute each of the below.
+
+1. Execute `update50` to ensure your IDE is up-to-date. That command might take a few minutes to finish.
+1. Execute `cd` to ensure that you're in `~/workspace/` (i.e., a directory called `workspace` that's in your home directory, aka `~`).
+1. Execute `mkdir pset3` to make (i.e., create) a directory called `pset3` in your home directory.
+1. Execute `cd pset3` to change into (i.e., open) that directory.
+1. Execute `wget http://cdn.cs50.net/2018/fall/psets/3/resize/less/resize.zip` to download a (compressed) ZIP file with this problem's distribution.
+1. Execute `unzip resize.zip` to uncompress that file.
+1. Execute `rm resize.zip` followed by `yes` or `y` to delete that ZIP file.
+1. Execute `ls`. You should see a directory called `resize`, which was inside of that ZIP file.
+1. Execute `cd resize` to change into that directory.
+1. Execute `ls`. You should see a directory called `less`.
+1. Execute `cd less` to change into that directory.
+1. Execute `ls`. You should see this problem's distribution, including `bmp.h`, `copy.c`, `large.bmp`, `small.bmp`, and `smiley.bmp`.
+
 == Background
 
 First, be sure you're familiar with the structure of 24-bit uncompressed BMPs, as introduced in link:https://lab.cs50.io/cs50/labs/2018/fall/whodunit[Whodunit].
@@ -91,23 +108,6 @@ For contrast, let's next look at `large.bmp`, which looks identical to `small.bm
 Worthy of note is that this BMP lacks padding! After all, (12 pixels) × (3 bytes per pixel) = 36 bytes is indeed a multiple of 4.
 
 Knowing all this has got to be useful!
-
-== Getting Started
-
-Here's how to download this problem's "distribution code" (i.e., starter code) into your own CS50 IDE. Log into [CS50 IDE](https://cs50.io/) and then, in a terminal window, execute each of the below.
-
-1. Execute `update50` to ensure your IDE is up-to-date. That command might take a few minutes to finish.
-1. Execute `cd` to ensure that you're in `~/workspace/` (i.e., a directory called `workspace` that's in your home directory, aka `~`).
-1. Execute `mkdir pset3` to make (i.e., create) a directory called `pset3` in your home directory.
-1. Execute `cd pset3` to change into (i.e., open) that directory.
-1. Execute `wget http://cdn.cs50.net/2018/fall/psets/3/resize/less/resize.zip` to download a (compressed) ZIP file with this problem's distribution.
-1. Execute `unzip resize.zip` to uncompress that file.
-1. Execute `rm resize.zip` followed by `yes` or `y` to delete that ZIP file.
-1. Execute `ls`. You should see a directory called `resize`, which was inside of that ZIP file.
-1. Execute `cd resize` to change into that directory.
-1. Execute `ls`. You should see a directory called `less`.
-1. Execute `cd less` to change into that directory.
-1. Execute `ls`. You should see this problem's distribution, including `bmp.h`, `copy.c`, `large.bmp`, `small.bmp`, and `smiley.bmp`.
 
 == Specification
 


### PR DESCRIPTION
Moved the Getting Started section to top, since the Background section assumes that the student already has access to the sample bitmap files.