### PR TITLE
correct crack password

### DIFF
--- a/_pages/2017/fall/psets/2/crack/crack.adoc
+++ b/_pages/2017/fall/psets/2/crack/crack.adoc
@@ -65,7 +65,7 @@ Usage: ./crack hash
 [source,subs=quotes]
 ----
 $ [underline]#./crack 50JGnXUgaafgc#
-ROFL
+rofl
 ----
 
 == Testing

--- a/_pages/2018/ap/problems/crack/crack.adoc
+++ b/_pages/2018/ap/problems/crack/crack.adoc
@@ -83,7 +83,7 @@ Usage: ./crack hash
 [source,subs=quotes]
 ----
 $ [underline]#./crack 50fkUxYHbnXGw#
-ROFL
+rofl
 ----
 
 == Testing

--- a/_pages/2018/x/psets/2/crack/crack.adoc
+++ b/_pages/2018/x/psets/2/crack/crack.adoc
@@ -65,7 +65,7 @@ Usage: ./crack hash
 [source,subs=quotes]
 ----
 $ [underline]#./crack 50JGnXUgaafgc#
-ROFL
+rofl
 ----
 
 == Testing


### PR DESCRIPTION
Long-standing 'typo' in the crack sample.  ` ./crack 50fkUxYHbnXGw` should crack to `rofl`  We use the example twice in the spec.  First time it is correct.  Second time, we've got `ROFL` by mistake.  Fixed.