### PR TITLE
update crack to match Fall 2017 specs

### DIFF
--- a/_pages/2018/ap/problems/crack/crack.adoc
+++ b/_pages/2018/ap/problems/crack/crack.adoc
@@ -40,16 +40,16 @@ Even though passwords in `/etc/shadow` are hashed, the hash function is not alwa
 
 [source]
 ----
-andi:50.jPgLzVirkc
-jason:50YHuxoCN9Jkc
-malan:50QvlJWn2qJGE
-mzlatkova:50CPlMDLT06yY
-patrick:50WUNAFdX/yjA
-rbowden:50fkUxYHbnXGw
-summer:50C6B0oz0HWzo
-stelios:50nq4RV/NVU0I
-wmartin:50vtwu4ujL.Dk
-zamyla:50i2t3sOSAZtk
+anushree:50xcIMJ0y.RXo
+brian:50mjprEcqC/ts
+bjbrown:50GApilQSG3E2
+lloyd:50n0AAUD.pL8g
+malan:50CcfIk1QrPr6
+maria:509nVI8B9VfuA
+natmelo:50JIIyhDORqMU
+rob:50JGnXUgaafgc
+stelios:51u8F0dkeDSbY
+zamyla:50cI2vYkF0YU2
 ----
 
 == Specification
@@ -61,7 +61,7 @@ Design and implement a program, `crack`, that cracks passwords.
 * If your program is executed without any command-line arguments or with more than one command-line argument, your program should print an error (of your choice) and exit immediately, with `main` returning `1` (thereby signifying an error).
 * Otherwise, your program must proceed to crack the given password, ideally as quickly as possible, ultimately printing the password in the clear followed by `\n`, nothing more, nothing less, with `main` returning `0`.
 * Assume that each password has been hashed with C's DES-based (not MD5-based) `crypt` function.
-* Assume that each password is no longer than (gasp) four characters
+* Assume that each password is no longer than five (5) characters. Gasp!
 * Assume that each password is composed entirely of alphabetical characters (uppercase and/or lowercase).
 
 == Walkthrough


### PR DESCRIPTION
The example hashes were all 4 chars or less (from Fall 2016) so updated them to the Fall 2017 version  (and also upped the "up to 4 chars" to 5 chars.