### PR TITLE
Fixed wrong bootstrap documentation link

### DIFF
--- a/_pages/web/2018/x/projects/0/project0.md
+++ b/_pages/web/2018/x/projects/0/project0.md
@@ -67,9 +67,9 @@ subject to the following requirements:
 * Your stylesheet(s) must include at least one mobile-responsive `@media` query,
   such that something about the styling changes for smaller screens.
 * You must use Bootstrap 4 on your website, taking advantage of at least one
-  Bootstrap [component](https://getbootstrap.com/docs/3.3/components/),
+  Bootstrap [component](https://getbootstrap.com/docs/4.3/components/),
   and using at least two Bootstrap columns for layout purposes using
-  Bootstrap's [grid model](https://getbootstrap.com/docs/4.0/layout/grid/).
+  Bootstrap's [grid model](https://getbootstrap.com/docs/4.3/layout/grid/).
 * Your stylesheets must use at least one SCSS variable, at least one example of
   SCSS nesting, and at least one use of SCSS inheritance.
 * In `README.md`, include a short writeup describing your project, what's


### PR DESCRIPTION
The Bootstrap components link was pointing to bootstrap v3.3. 
I updated it to v4.3, for consistency, the bootstrap grid links also points to v4.3 now